### PR TITLE
Uppdatera mailkontakt om infon är fel

### DIFF
--- a/Office365-Scoutnet-synk/Office365-Scoutnet-synk.psm1
+++ b/Office365-Scoutnet-synk/Office365-Scoutnet-synk.psm1
@@ -90,21 +90,69 @@ function New-SNSMailContact
             {
                 # It takes some time befor the new contact can be accessed. Wait and try to access it.
                 Start-Sleep -s 1.0
-                $ExistingMailContact = Get-EXORecipient $Epost -ErrorAction "SilentlyContinue" -Verbose:$false
+                $ExistingMailContact = Get-Contact $Epost -ErrorAction "SilentlyContinue" -Verbose:$false
                 if ($null -ne $ExistingMailContact)
                 {
                     $i = 10
                 }
             }
 
-            # Set the name of the member in the company field. This is visibel in Office 365 admin console.
-            Set-Contact -Identity $Epost -Company "$DisplayName" -Verbose:$false
-            Set-MailContact -Identity $Epost -HiddenFromAddressListsEnabled $true -Verbose:$false
+            try
+            {
+                # Set the name of the member in the company field. This is visibel in Office 365 admin console.
+                Set-Contact -Identity $Epost -Company "$DisplayName" -ErrorAction "stop" -Verbose:$false
+                try
+                {
+                    # Hide the contact from address lists.
+                    Set-MailContact -Identity $Epost -HiddenFromAddressListsEnabled $true -ErrorAction "stop" -Verbose:$false
+                }
+                Catch
+                {
+                    Write-SNSLog -Level "Warn" "Could not set hidden from address lists field for $Epost, will try again next time the sync runs. Error $_"
+                }
+            }
+            Catch
+            {
+                Write-SNSLog -Level "Warn" "Could not set company field for $Epost, will try again next time the sync runs. Error $_"
+            }
         }
         Catch
         {
             Write-SNSLog -Level "Warn" "Could not create mail contact with address $Epost. Error $_"
             $contactCreated = $False
+        }
+    }
+    else
+    {
+        try
+        {
+            $MailContactInfo = Get-Contact $Epost -ErrorAction "SilentlyContinue" -Verbose:$false
+            # Set the company field for the existing contact and hide it from address lists if necessary.
+            if ($MailContactInfo.Company -eq "")
+            {
+                try
+                {
+                    # Set the company field for the existing contact.
+                    Set-Contact -Identity $Epost -Company "$DisplayName" -ErrorAction "stop" -Verbose:$false
+                    try
+                    {
+                        # Hide the contact from address lists.
+                        Set-MailContact -Identity $Epost -HiddenFromAddressListsEnabled $true -ErrorAction "stop" -Verbose:$false
+                    }
+                    Catch
+                    {
+                        Write-SNSLog -Level "Warn" "Could not set hidden from address lists field for $Epost, will try again next time the sync runs. Error $_"
+                    }
+                }
+                Catch
+                {
+                    Write-SNSLog -Level "Warn" "Could not set company field for $Epost, will try again next time the sync runs. Error $_"
+                }
+            }
+        }
+        Catch
+        {
+            Write-SNSLog -Level "Warn" "Could not get mail contact info for $Epost, will try again next time the sync runs. Error $_"
         }
     }
 

--- a/Office365-Scoutnet-synk/SNSConfiguration.ps1
+++ b/Office365-Scoutnet-synk/SNSConfiguration.ps1
@@ -258,7 +258,8 @@ function New-SNSConfiguration
     $conf.commandNames += "Set-MailContact,Set-Mailbox,Remove-DistributionGroupMember,"
     $conf.commandNames += "Add-DistributionGroupMember,Get-DistributionGroupMember,"
     $conf.commandNames += "Get-DistributionGroup,Set-MailboxMessageConfiguration,"
-    $conf.commandNames += "Set-MailboxAutoReplyConfiguration"
+    $conf.commandNames += "Set-MailboxAutoReplyConfiguration,"
+    $conf.commandNames += "Get-Contact"
 
     return $conf
 }


### PR DESCRIPTION
När en mailkontakt skapas så behöver inte skriptet lyckas med att sätta fältet "company" till scoutens namn samt sätta
parametern HiddenFromAddressListsEnabled.

För att hantera det så kollar skriptet att information är inskriven när existerande kontakt används i efterföljande körningar.

Namnet i company kan inte ändras då en kontakt kan vara till flera scouter om de har samma kontakt till anhöriga.

Fixes: gh-42